### PR TITLE
scipy to 1.5

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 matplotlib>=3.0.0
 numpy>=1.17.0
 scikit-learn>=0.19.1
-scipy>=1.4.0
+scipy>=1.5.0
 seaborn>=0.9.0
 joblib>=0.11


### PR DESCRIPTION
scipy.eigh is called in [`utils.linalg.py`](https://github.com/mvlearn/mvlearn/blob/master/mvlearn/utils/linalg.py#L139) with the `subset_by_index` parameter which is only available in [scipy >= 1.5](https://docs.scipy.org/doc/scipy-1.5.0/reference/generated/scipy.linalg.eigh.html).

This updates the base requirement of scipy from >=1.4 to >=1.5